### PR TITLE
Add missing cctype header (required for std::tolower)

### DIFF
--- a/src/mini/ini.h
+++ b/src/mini/ini.h
@@ -92,6 +92,7 @@
 #include <memory>
 #include <fstream>
 #include <sys/stat.h>
+#include <cctype>
 
 namespace mINI
 {


### PR DESCRIPTION
This PR adds a missing cctype header, required to use std::tolower (this was only an issue when compiling with the MSVC compiler on Windows, not with GCC/Clang on Linux).