### PR TITLE
Fix gcc8.5 build error

### DIFF
--- a/src/mini/ini.h
+++ b/src/mini/ini.h
@@ -108,7 +108,7 @@ namespace mINI
 		inline void toLower(std::string& str)
 		{
 			std::transform(str.begin(), str.end(), str.begin(), [](const char c) {
-				return static_cast<const char>(std::tolower(c));
+				return static_cast<char>(std::tolower(c));
 			});
 		}
 #endif


### PR DESCRIPTION
This is a fix for build failure when -Werror is enabled  and gcc8.X is used
`app/thirdparty/mINI/src/mini/ini.h:111:51: error: type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]`
